### PR TITLE
[DOC] Use logging configuration logFileInfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ like shown in the following example (writer configuration and file names can be 
             'writerConfiguration' => [
                 \TYPO3\CMS\Core\Log\LogLevel::INFO => [
                     \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-                        'logFile' => 'typo3temp/var/log/sudoMode.log'
+                        'logFileInfix' => 'sudo'
                     ],
                 ],
             ],

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ like shown in the following example (writer configuration and file names can be 
             'writerConfiguration' => [
                 \TYPO3\CMS\Core\Log\LogLevel::INFO => [
                     \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-                        'logFileInfix' => 'sudo'
+                        'logFileInfix' => 'sudo_mode'
                     ],
                 ],
             ],


### PR DESCRIPTION
The setting `logFileInfix` avoids possible security issues by defining insecure paths to log files + makes it easier to ship & deploy configurations